### PR TITLE
Fixed issue with cached redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN npm run build
 ENV PORT 80
 ENV NODE_ENV production
 EXPOSE 80
-CMD ["node", "backend/backend.js"]
+CMD ["node", "backend/server.js"]

--- a/backend/app.js
+++ b/backend/app.js
@@ -15,7 +15,11 @@ function randomID() {
   return "" + Math.floor(Math.random() * 10000000);
 }
 
-app.get("/", (req, res) => res.redirect(301, "/" + randomID()));
+app.get("/", (req, res) => {
+  const new_id = randomID();
+  console.log(`Redirecting '/' -> '/${new_id}' (302)`);
+  res.redirect(302, "/" + new_id);
+});
 
 app.get("/:id/", (req, res) => {
   res.sendFile("./index.html", { root: "frontend/dist" });

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,7 @@
 const app = require("./app.js").app;
 
+// Start server on port 80:
 const port = 80;
-// Serve the files on port 80.
 app.listen(port, function () {
-  console.log("Example app listening on port 80!\n");
+  console.log("nowcode server listening on port " + port);
 });

--- a/dev-server.js
+++ b/dev-server.js
@@ -1,9 +1,10 @@
-// This is identical to backend/backend.js
-// except we can add dev only things here, like webpack middleware
+// This is identical to backend/server.js
+// except we use port 3000 and can add dev only things
 
 const app = require("./backend/app.js").app;
 
-// Serve the files on port 3000.
-app.listen(3000, function () {
-  console.log("Example app listening on port 3000!\n");
+// Start server on port 3000:
+const port = 3000;
+app.listen(port, function () {
+  console.log("nowcode dev-server listening on port" + port);
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "gulp",
     "test": "node backend/app.js && mocha",
     "dev-server": "nodemon dev-server.js",
-    "server": "node backend/backend.js"
+    "server": "node backend/server.js"
   },
   "repository": {
     "type": "git",

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,0 @@
-{% extends "base.html" %}
-{% block main %}
-<form action="/new">
-    <input class="new_button" type="submit" value="Create new" />
-</form>
-{% endblock %}


### PR DESCRIPTION
Changed response code from 301 to 302.

301 is "Permanently moved".

302 is "Temporary Redirect / Found".

Chrome seems to cache the 301 redirect, which is not what we want.
(We want it to redirect to a new buffer every time).

In the future we should probably just do this in the frontend,
without a separate request.