### PR TITLE
gulpfile.js: Fixed html inlining

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,12 +8,12 @@ var gulp = require("gulp"),
   uglify = require("gulp-uglify"),
   sourcemaps = require("gulp-sourcemaps"),
   babelify = require("babelify"),
-  inline = require("gulp-inline-source"),
+  inlinesource = require("gulp-inline-source"),
   fs = require("fs"),
   path = require("path");
 
 gulp.task("default", function (done) {
-  gulp.series(["styles", "scripts", "html"], "inline", "copy")();
+  gulp.series(["styles", "scripts", "copy"], "html")();
   done();
 });
 
@@ -49,22 +49,14 @@ gulp.task("scripts", function () {
 });
 
 gulp.task("html", function () {
-  return gulp.src("frontend/src/index.html").pipe(gulp.dest("./frontend/dist"));
-});
+  var options = {
+    compress: false,
+    rootpath: path.resolve("frontend/dist"),
+  };
 
-gulp.task("inline", function (done) {
-  htmlpath = path.resolve("frontend/dist/index.html");
-  inline(
-    htmlpath,
-    {
-      compress: true,
-      rootpath: path.resolve("dist"),
-    },
-    function (err, html) {
-      fs.writeFileSync("frontend/dist/index.html", html);
-    }
-  );
-  done();
+  return gulp.src('./frontend/src/index.html')
+      .pipe(inlinesource(options))
+      .pipe(gulp.dest('./frontend/dist'));
 });
 
 gulp.task('copy', function (done) {


### PR DESCRIPTION
I guess this has been broken for a while, possibly since I upgraded
gulp version, but I didn't notice since it copied over the html
without inlining first. So everything worked, but this fixes the
actual inlining.

New gulp task is based on this example:

https://github.com/fmal/gulp-inline-source/blob/ccf6775703ab1145260eae045e423c785834974c/README.md#usage